### PR TITLE
WIP: fine-grained error handling

### DIFF
--- a/proof_of_function_relation/src/discrete_log_comparison/mod.rs
+++ b/proof_of_function_relation/src/discrete_log_comparison/mod.rs
@@ -83,7 +83,7 @@ where
             &domain_k,
             &ck,
             rng,
-        )?;
+        ).map_err(|_| Error::DLPlaceholderError)?;
 
         // Zero over K for g = (g')^2
         let g_prime_square_proof = ZeroOverK::<F, PC, D>::prove(
@@ -95,7 +95,7 @@ where
             &domain_k,
             &ck,
             rng,
-        )?;
+        ).map_err(|_| Error::DLPlaceholderError)?;
 
         // Zero over K for s = (s')^2
         let s_prime_square_proof = ZeroOverK::<F, PC, D>::prove(
@@ -110,7 +110,7 @@ where
             &domain_k,
             &ck,
             rng,
-        )?;
+        ).map_err(|_| Error::DLPlaceholderError)?;
 
         // // SANITY CHECK
         // for element in domain_k.elements() {
@@ -144,7 +144,7 @@ where
             &domain_k,
             &ck,
             rng,
-        )?;
+        ).map_err(|_| Error::DLPlaceholderError)?;
 
         let delta = prover_state
             .delta
@@ -166,7 +166,7 @@ where
             &c_s,
             &domain_k,
             rng,
-        )?;
+        ).map_err(|_| Error::DLPlaceholderError)?;
 
         // Subset over K for f'
         let f_prime_subset_proof = SubsetOverK::<F, PC, D>::prove();
@@ -183,7 +183,7 @@ where
             domain_k,
             prover_first_oracles.f_prime.clone(),
             rng,
-        )?;
+        ).map_err(|_| Error::DLPlaceholderError)?;
 
         // Non-zero over K for g′
         let nzk_g_prime_proof = NonZeroOverK::<F, PC, D>::prove(
@@ -191,7 +191,7 @@ where
             domain_k,
             prover_first_oracles.g_prime.clone(),
             rng,
-        )?;
+        ).map_err(|_| Error::DLPlaceholderError)?;
 
         // Non-zero over K for s′
         let nzk_s_prime_proof = NonZeroOverK::<F, PC, D>::prove(
@@ -199,7 +199,7 @@ where
             domain_k,
             prover_first_oracles.s_prime.clone(),
             rng,
-        )?;
+        ).map_err(|_| Error::DLPlaceholderError)?;
 
         // Non-zero over K for s(X) − 1
         // it's important to note that verifier will derive S(x) - 1 commitment on it's own side
@@ -208,7 +208,10 @@ where
         let s_minus_one = prover_first_oracles.s.polynomial() - one_poly.polynomial();
         let s_minus_one = label_polynomial!(s_minus_one);
         let nzk_s_minus_one_proof =
-            NonZeroOverK::<F, PC, D>::prove(ck, domain_k, s_minus_one.clone(), rng)?;
+            NonZeroOverK::<F, PC, D>::prove(
+                ck, domain_k, s_minus_one.clone(), rng
+            )
+            .map_err(|_| Error::DLPlaceholderError)?;
 
         let proof = Proof {
             // Commitments

--- a/proof_of_function_relation/src/error.rs
+++ b/proof_of_function_relation/src/error.rs
@@ -1,8 +1,9 @@
 #[derive(Debug, PartialEq)]
 #[allow(dead_code)]
 pub enum Error {
-    MaxDegreeExceeded,
     PCError { error: String },
+    FEvalIsZero,
+    MaxDegreeExceeded,
     Check1Failed,
     Check2Failed,
     ProofVerificationError,
@@ -11,8 +12,14 @@ pub enum Error {
     InstantiationError,
     InvalidGeoSeq,
     T2Large,
+
+    // These will be replaced
+    DLPlaceholderError,
+    TDiagPlaceholderError,
+    GeoSeqPlaceholderError,
 }
 
+// TODO: obsolete this
 /// Convert an ark_poly_commit error
 pub fn to_pc_error<F, PC>(error: PC::Error) -> Error
 where

--- a/proof_of_function_relation/src/errors/lib.rs
+++ b/proof_of_function_relation/src/errors/lib.rs
@@ -1,0 +1,1 @@
+mod zero_over_k;

--- a/proof_of_function_relation/src/errors/mod.rs
+++ b/proof_of_function_relation/src/errors/mod.rs
@@ -1,0 +1,1 @@
+pub mod zero_over_k;

--- a/proof_of_function_relation/src/errors/zero_over_k.rs
+++ b/proof_of_function_relation/src/errors/zero_over_k.rs
@@ -1,0 +1,5 @@
+pub enum ZeroOverKError {
+    Check1Failed,
+    Check2Failed,
+    FPrimeEvalsInstantiationError,
+}

--- a/proof_of_function_relation/src/geo_seq/mod.rs
+++ b/proof_of_function_relation/src/geo_seq/mod.rs
@@ -81,8 +81,7 @@ impl<F: PrimeField, PC: HomomorphicPolynomialCommitment<F>, D: Digest> GeoSeqTes
             separation_challenge,
             &[f_rand.clone()],
             None,
-        )
-        .map_err(to_pc_error::<F, PC>)?;
+        ).map_err(|_| Error::GeoSeqPlaceholderError)?;
 
         let z_proof = ZeroOverK::<F, PC, D>::prove(
             &[f.clone()],
@@ -93,7 +92,7 @@ impl<F: PrimeField, PC: HomomorphicPolynomialCommitment<F>, D: Digest> GeoSeqTes
             &domain,
             &ck,
             rng,
-        )?;
+        ).map_err(|_| Error::GeoSeqPlaceholderError)?;
 
         let proof = Proof::<F, PC> {
             z_proof,

--- a/proof_of_function_relation/src/non_zero_over_k/errors.rs
+++ b/proof_of_function_relation/src/non_zero_over_k/errors.rs
@@ -1,0 +1,6 @@
+#[derive(Debug, PartialEq)]
+pub enum NonZeroOverKError {
+    FEvalIsZero,
+    PCError,
+    ZeroOverKProofError,
+}

--- a/proof_of_function_relation/src/non_zero_over_k/tests.rs
+++ b/proof_of_function_relation/src/non_zero_over_k/tests.rs
@@ -6,6 +6,7 @@ mod test {
         non_zero_over_k::NonZeroOverK,
         util::sample_vector,
         virtual_oracle::{inverse_check_oracle::InverseCheckOracle, VirtualOracle},
+        non_zero_over_k::errors,
     };
     use ark_bn254::{Bn254, Fr};
     use ark_ff::{Field, One, Zero};
@@ -52,12 +53,13 @@ mod test {
     }
 
     #[test]
-    #[should_panic]
-    fn rand_failig_test() {
+    fn test_f_eval_is_zero() {
         let mut rng = thread_rng();
         let n = 8;
 
         let mut f_evals: Vec<F> = sample_vector(&mut rng, n);
+
+        // Set one of the f_evals to zero, which will cause an error
         f_evals[4] = F::zero();
 
         let domain = GeneralEvaluationDomain::<F>::new(n).unwrap();
@@ -69,7 +71,13 @@ mod test {
         let pp = PC::setup(max_degree, None, &mut rng).unwrap();
         let (ck, _) = PC::trim(&pp, max_degree, 0, None).unwrap();
 
-        // panic here because there is no inverse of 0
-        let proof = NonZeroOverK::<F, PC, Blake2s>::prove(&ck, &domain, f, &mut rng).unwrap();
+        let proof = NonZeroOverK::<F, PC, Blake2s>::prove(&ck, &domain, f, &mut rng);
+
+        // Test whether the correct error is thrown. In this case
+        assert!(proof.is_err());
+        assert_eq!(
+            proof.err().unwrap(),
+            errors::NonZeroOverKError::FEvalIsZero
+        );
     }
 }

--- a/proof_of_function_relation/src/t_diag/mod.rs
+++ b/proof_of_function_relation/src/t_diag/mod.rs
@@ -138,7 +138,7 @@ where
             domain_k,
             ck,
             rng,
-        )?;
+        ).map_err(|_| Error::TDiagPlaceholderError)?;
 
         // Step 4c: Zero over K for rowM = colM
         let row_m_eq_col_m = ZeroOverK::<F, PC, D>::prove(
@@ -150,7 +150,7 @@ where
             domain_k,
             ck,
             rng,
-        )?;
+        ).map_err(|_| Error::TDiagPlaceholderError)?;
 
         // Step 5: Zero over K for valM * h2 = 0
         let prod_vo = ProdVO::new();
@@ -163,13 +163,13 @@ where
             domain_k,
             ck,
             rng,
-        )?;
+        ).map_err(|_| Error::TDiagPlaceholderError)?;
 
         // Step 6: Non-zero over K for valM + h2 != 0
         let val_plus_h2 = val_m.polynomial() + h2.polynomial();
         let val_plus_h2 = label_polynomial!(val_plus_h2);
 
-        let val_plus_h2_proof = NonZeroOverK::<F, PC, D>::prove(ck, domain_k, val_plus_h2, rng)?;
+        let val_plus_h2_proof = NonZeroOverK::<F, PC, D>::prove(ck, domain_k, val_plus_h2, rng).map_err(|_| Error::TDiagPlaceholderError)?;
 
         let proof = Proof {
             h1_commit: h_commitments[0].commitment().clone(),

--- a/proof_of_function_relation/src/t_functional_triple/errors.rs
+++ b/proof_of_function_relation/src/t_functional_triple/errors.rs
@@ -1,0 +1,14 @@
+use crate::error::Error;
+use crate::non_zero_over_k;
+
+#[derive(Debug, PartialEq)]
+pub enum TftError {
+    //TsltAProofError(non_zero_over_k::errors::NonZeroOverKError),
+    TsltAProofError(Error),
+    TsltBProofError(Error),
+    TdiagProofError(Error),
+
+    TsltAVerifyError(Error),
+    TsltBVerifyError(Error),
+    TdiagVerifyError(Error),
+}

--- a/proof_of_function_relation/src/zero_over_k/errors.rs
+++ b/proof_of_function_relation/src/zero_over_k/errors.rs
@@ -1,0 +1,15 @@
+use crate::error::Error;
+use crate::non_zero_over_k;
+
+#[derive(Debug, PartialEq)]
+pub enum ZeroOverKError {
+    ProverInitError,
+    ProverFirstRoundError,
+    VerifierInitError,
+    VerifierFirstRoundError,
+    VerifierQuerySetError,
+    PCErrorR,
+    PCErrorM,
+    PCErrorQ1,
+    PCErrorBatchOpen,
+}


### PR DESCRIPTION
This PR introduces fine-grained error handling. It's still a work in progress and I would love any feedback please!

Previously, all errors were part of an `enum` in `src/error.rs`.

Now, each module contains its own `errors.rs`. Take `src/non_zero_over_k/errors.rs` for example: it contains an enum `NonZeroOverKError` of specific errors that can be thrown by any functions in the non-zok module. e.g. `FEvalIsZero`.

This allows the tests to perform failing unit tests. For example, the `test_f_eval_is_zero` test in `src/non_zero_over_k/tests.rs` now checks if the prover throws a `errors::NonZeroOverKError::FEvalIsZero` error if one of the `f_evals` values is set to 0. Previously, the test would just panic but there was no way to tell if the panic was due to the desired reason.

Work in progress: an easier way to bubble up errors. For example, the last test in `t_functional_triple/tests.rs` checks if an error equals `errors::TftError::TsltAProofError(Error::DLPlaceholderError)`. `Error::DLPlaceholderError` is just a placeholder and in the future the error to check against will be something like:

```
errors::TftError::TsltAProofError(dlc_errors::DlcError::FNotEqualToFPrimeSquared)
```

Hope this makes sense! Please let me know what you think. Thanks!
